### PR TITLE
Start to working cmos driver that matches current unix time, add test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.o
 *.log
 os.iso
-kernel.elf
+**/*.elf
 img/*
+.vagrant/

--- a/.lvimrc
+++ b/.lvimrc
@@ -1,6 +1,6 @@
 let g:neomake_c_enabled_makers = ['gcc']
 let g:neomake_gcc_maker = {
     \ 'exe': '/usr/bin/gcc',
-    \ 'args': ['-m32', '-nostdlib', '-nostdinc', '-fno-builtin', '-fno-stack-protector', '-nodefaultlibs', '-Wall', '-Wextra', '-Werror', '-c', '-ggdb', '-Ikernel/include'],
+    \ 'args': ['-m32', '-nostdlib', '-nostdinc', '-fno-builtin', '-fno-stack-protector', '-nodefaultlibs', '-Wall', '-Wextra', '-Werror', '-c', '-ggdb', '-Ikernel/include', '-o /dev/null'],
     \ 'errorformat': '%f:%l:%c: %m',
     \ }

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC = gcc
 CFLAGS = -m32 -nostdlib -nostdinc -fno-builtin -fno-stack-protector \
-	 -nostartfiles -nodefaultlibs -Wall -Wextra -c -ggdb \
+	 -nostartfiles -nodefaultlibs -Wall -Wextra -Werror -c -ggdb \
 	 -I kernel/include
 LDFLAGS = -T link.ld -melf_i386
 AS = nasm

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC = gcc
 CFLAGS = -m32 -nostdlib -nostdinc -fno-builtin -fno-stack-protector \
-	 -nostartfiles -nodefaultlibs -Wall -Wextra -Werror -c -ggdb \
+	 -nostartfiles -nodefaultlibs -Wall -Wextra -c -ggdb \
 	 -I kernel/include
 LDFLAGS = -T link.ld -melf_i386
 AS = nasm
@@ -12,6 +12,8 @@ KERNEL_OBJS = $(patsubst %.c,%.o,$(wildcard kernel/*.c))
 KERNEL_OBJS += $(patsubst %.s,%.o,$(wildcard *.s))
 KERNEL_OBJS += $(patsubst %.c,%.o,$(wildcard *.c))
 KERNEL_OBJS += $(patsubst %.c,%.o,$(wildcard kernel/devices/*.c))
+TEST_OBJS = $(patsubst %.c,%.o,$(wildcard tests/*.c))
+TEST_OBJS += $(patsubst %.s,%.o,$(wildcard tests/*.s))
 
 all: os.iso
 
@@ -33,4 +35,10 @@ kernel.elf: $(KERNEL_OBJS)
 	$(AS) $(ASFLAGS) $< -o $@
 
 clean:
-	rm -rf *.o img os.iso
+	rm -rf **.o img os.iso
+
+test: $(TEST_OBJS) $(KERNEL_OBJS)
+	ld -melf_i386 $(KERNEL_OBJS) $(TEST_OBJS) -o tests/test.elf
+	qemu-i386-static tests/test.elf | tappy
+
+

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,11 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+  config.vm.box = "ubuntu/xenial64"
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = "1024"
+  end
+  # TODO: Install pip, tappy, qemu user mode tools
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@ $script = <<-SCRIPT
 echo Starting provisioning...
 # Install qemu user mode and tappy to run
 # our TAP unit tests
-apt-get update && apt-get install -y qemu-user-static python-pip
+apt-get update && apt-get install -y qemu-user-static python-pip gdb
 pip install tappy tap.py
 SCRIPT
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,11 +1,19 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+$script = <<-SCRIPT
+echo Starting provisioning...
+# Install qemu user mode and tappy to run
+# our TAP unit tests
+apt-get update && apt-get install -y qemu-user-static python-pip
+pip install tappy tap.py
+SCRIPT
+
 Vagrant.configure(2) do |config|
   config.vm.box = "ubuntu/xenial64"
 
   config.vm.provider "virtualbox" do |vb|
     vb.memory = "1024"
   end
-  # TODO: Install pip, tappy, qemu user mode tools
+  config.vm.provision "shell", inline: $script
 end

--- a/io.s
+++ b/io.s
@@ -2,10 +2,6 @@ global outb
 global inb
 global print
 
-section .data
-msg db  'Hello, world! asdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfsssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss',0xa ;our dear string
-len equ $ - msg         ;length of our dear string
-
 outb:
     mov al, [esp + 8]
     mov dx, [esp + 4]

--- a/io.s
+++ b/io.s
@@ -1,5 +1,10 @@
 global outb
 global inb
+global print
+
+section .data
+msg db  'Hello, world! asdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfsssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss',0xa ;our dear string
+len equ $ - msg         ;length of our dear string
 
 outb:
     mov al, [esp + 8]
@@ -10,4 +15,15 @@ outb:
 inb:
     mov dx, [esp + 4]
     in al, dx
+    ret
+
+; to be used in qemu in user mode only!
+; This OS does not have support for a write syscall
+; at the moment!
+print:
+    mov edx, [esp + 8]
+    mov ecx, [esp + 4]
+    mov ebx,1   ;file descriptor (stdout)
+    mov eax,4   ;system call number (sys_write)
+    int 0x80    ;call kernel
     ret

--- a/isr.c
+++ b/isr.c
@@ -23,7 +23,7 @@ void register_interrupt_handler(uint8_t n, isr_t handler)
 // This gets called from our ASM interrupt handler stub.
 void irq_handler(registers_t regs)
 {
-    serial_write("Received interrupt");
+    /* serial_write("Received interrupt"); */
    // Send an EOI (end of interrupt) signal to the PICs.
    // If this interrupt involved the slave.
    if (regs.int_no >= 40)

--- a/kernel/devices/cmos.c
+++ b/kernel/devices/cmos.c
@@ -154,7 +154,7 @@ uint32_t read_cmos()
     vasprintf(buf, sizeof(buf)/sizeof(buf[0]), "Booting at seconds: %d  mins: %d  hour: %d  day: %d month: %d  year: %d  unixtime: %d \n", bcd2dec(values[CMOS_SECOND]), bcd2dec(values[CMOS_MINUTE]), bcd2dec(values[CMOS_HOUR]), bcd2dec(values[CMOS_DAY_MONTH]), bcd2dec(values[CMOS_MONTH]), bcd2dec(values[CMOS_YEAR]), time);
     serial_write(buf);
 
-    return 0;
+    return time;
 }
 
 uint32_t get_timestamp_from_cmos_registers(

--- a/kernel/devices/cmos.c
+++ b/kernel/devices/cmos.c
@@ -1,4 +1,5 @@
 #include "cmos.h"
+#include "system.h"
 #include "io.h"
 #include "serial.h"
 #include "libc.h"
@@ -6,11 +7,86 @@
 #define CMOS_ADDR 0x70
 #define CMOS_DATA 0x71
 
+// When using qemu with the local clock it 
+// is timezone dependent.
+#define TZ_OFFSET 4
+
 uint32_t boot_time = 0;
+
+// Took this from qemu https://github.com/qemu/qemu/blob/master/tests/rtc-test.c#L24
+static int bcd2dec(int value)
+{
+    return (((value >> 4) & 0x0F) * 10) + (value & 0x0F);
+}
+
+uint32_t secs_of_years(int years) {
+	uint32_t days = 0;
+	years += 2000;
+	while (years > 1969) {
+		days += 365;
+		if (years % 4 == 0) {
+			if (years % 100 == 0) {
+				if (years % 400 == 0) {
+					days++;
+				}
+			} else {
+				days++;
+			}
+		}
+		years--;
+	}
+	return days * 86400;
+}
+
+uint32_t secs_of_month(int months, int year) {
+	year += 2000;
+
+	uint32_t days = 0;
+	switch(months) {
+		case 11:
+			days += 30;
+		case 10:
+			days += 31;
+		case 9:
+			days += 30;
+		case 8:
+			days += 31;
+		case 7:
+			days += 31;
+		case 6:
+			days += 30;
+		case 5:
+			days += 31;
+		case 4:
+			days += 30;
+		case 3:
+			days += 31;
+		case 2:
+			days += 28;
+			if ((year % 4 == 0) && ((year % 100 != 0) || (year % 400 == 0))) {
+				days++;
+			}
+		case 1:
+			days += 31;
+		default:
+			break;
+	}
+	return days * 86400;
+}
+
+enum {
+    CMOS_SECOND = 0x0,
+    CMOS_MINUTE = 0x2,
+    CMOS_HOUR = 0x4,
+    CMOS_DAY_WEEK = 0x6,
+    CMOS_DAY_MONTH = 0x7,
+    CMOS_MONTH = 0x8,
+    CMOS_YEAR = 0x9
+};
 
 int update_in_progress()
 {
-    outb(CMOS_ADDR, 0xa);
+    outb(CMOS_ADDR, 0x0a);
     return inb(CMOS_DATA) & 0x80;
 }
 
@@ -22,15 +98,73 @@ void cmos_dump(uint16_t *values)
     }
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+// TODO: Change tz to correct pointer
+int gettimeofday(struct timeval *tv, void *tz)
+{
+    tv->tv_sec = boot_time + timer_ticks;
+    tv->tv_usec = timer_subticks * 1000;
+    return 0;
+}
+#pragma GCC diagnostic pop
+
 uint32_t read_cmos()
 {
     uint16_t values[10];
     uint16_t old_values[10];
-
     while (update_in_progress()) {
+        serial_write("updating\n");
     }
 
     cmos_dump(values);
-    memcpy(values, old_values, 10);
+    // TODO: Stuck in infinite CMOS loop
+    do {
+
+        memcpy(old_values, values, 20);
+        while (update_in_progress()) {
+            serial_write("inner update\n");
+        }
+
+        cmos_dump(values);
+    } while (
+        values[CMOS_SECOND] != old_values[CMOS_SECOND] ||
+        values[CMOS_MINUTE] != old_values[CMOS_MINUTE] ||
+        values[CMOS_HOUR] != old_values[CMOS_HOUR] ||
+        values[CMOS_DAY_WEEK] != old_values[CMOS_DAY_WEEK] ||
+        values[CMOS_DAY_MONTH] != old_values[CMOS_DAY_MONTH] ||
+        values[CMOS_MONTH] != old_values[CMOS_MONTH] ||
+        values[CMOS_YEAR] != old_values[CMOS_YEAR]
+    );
+    serial_write("done updating cmos\n");
+    char buf[1000];
+    serial_write(buf);
+    uint32_t time = bcd2dec(values[CMOS_SECOND]) +
+        bcd2dec(values[CMOS_MINUTE]) * 60 +
+        bcd2dec(values[CMOS_HOUR] + TZ_OFFSET) * 60 * 60 +
+        (bcd2dec(values[CMOS_DAY_MONTH]) - 1) * 86400 + // 24 * 60 * 60
+        secs_of_month(bcd2dec(values[CMOS_MONTH]) - 1,
+                bcd2dec(values[CMOS_YEAR])) +
+        secs_of_years(bcd2dec(values[CMOS_YEAR]) - 1);
+
+    vasprintf(buf, sizeof(buf)/sizeof(buf[0]), "seconds: %d  mins: %d  hour: %d  day: %d month: %d  year: %d  unixtime: %d \n", bcd2dec(values[CMOS_SECOND]), bcd2dec(values[CMOS_MINUTE]), bcd2dec(values[CMOS_HOUR]), bcd2dec(values[CMOS_DAY_MONTH]), bcd2dec(values[CMOS_MONTH]), bcd2dec(values[CMOS_YEAR]), time);
+
     return 0;
+}
+
+uint32_t get_timestamp_from_cmos_registers(
+    uint32_t secs,
+    uint32_t mins,
+    uint32_t hours,
+    uint32_t days,
+    uint32_t months,
+    uint32_t years
+)
+{
+    return secs +
+        mins * 60 +
+        (hours + TZ_OFFSET ) * 60 * 60 +
+        (days - 1) * 86400 + // 24 * 60 * 60
+        secs_of_month(months - 1, years) +
+        secs_of_years(years - 1);
 }

--- a/kernel/devices/cmos.c
+++ b/kernel/devices/cmos.c
@@ -101,6 +101,10 @@ void cmos_dump(uint16_t *values)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 // TODO: Change tz to correct pointer
+
+// This also needs to be validated that it works.
+// Having issues because I think output buffering is
+// causing the logs to appear to be delayed.
 int gettimeofday(struct timeval *tv, void *tz)
 {
     tv->tv_sec = boot_time + timer_ticks;
@@ -147,7 +151,8 @@ uint32_t read_cmos()
                 bcd2dec(values[CMOS_YEAR])) +
         secs_of_years(bcd2dec(values[CMOS_YEAR]) - 1);
 
-    vasprintf(buf, sizeof(buf)/sizeof(buf[0]), "seconds: %d  mins: %d  hour: %d  day: %d month: %d  year: %d  unixtime: %d \n", bcd2dec(values[CMOS_SECOND]), bcd2dec(values[CMOS_MINUTE]), bcd2dec(values[CMOS_HOUR]), bcd2dec(values[CMOS_DAY_MONTH]), bcd2dec(values[CMOS_MONTH]), bcd2dec(values[CMOS_YEAR]), time);
+    vasprintf(buf, sizeof(buf)/sizeof(buf[0]), "Booting at seconds: %d  mins: %d  hour: %d  day: %d month: %d  year: %d  unixtime: %d \n", bcd2dec(values[CMOS_SECOND]), bcd2dec(values[CMOS_MINUTE]), bcd2dec(values[CMOS_HOUR]), bcd2dec(values[CMOS_DAY_MONTH]), bcd2dec(values[CMOS_MONTH]), bcd2dec(values[CMOS_YEAR]), time);
+    serial_write(buf);
 
     return 0;
 }

--- a/kernel/devices/timer.c
+++ b/kernel/devices/timer.c
@@ -6,14 +6,19 @@
 #include "libc.h"
 #include "system.h"
 
-uint32_t tick = 0;
+#define SUBTICKS_PER_TICK 1000
+
+uint32_t timer_ticks = 0;
+uint32_t timer_subticks = 0;
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 static void timer_callback(registers_t reg)
 {
-    tick++;
-    serial_write("Tick: ");
+    if (++timer_subticks == SUBTICKS_PER_TICK) {
+        timer_subticks = 0;
+        timer_ticks++;
+    }
 }
 #pragma GCC diagnostic pop
 

--- a/kernel/include/cmos.h
+++ b/kernel/include/cmos.h
@@ -4,5 +4,8 @@
 #include "types.h"
 
 uint32_t read_cmos();
+uint32_t secs_of_years(int years);
+uint32_t secs_of_month(int months, int year);
+int gettimeofday(struct timeval *tv, void *tz);
 
 #endif

--- a/kernel/include/io.h
+++ b/kernel/include/io.h
@@ -1,3 +1,5 @@
+#include "types.h"
+
 #ifndef INCLUDE_IO_H
 #define INCLUDE_IO_H
 
@@ -16,5 +18,17 @@ void outb(unsigned short port, unsigned char data);
  *  @return      The read byte
  */
 unsigned char inb(unsigned short port);
+
+/** print:
+ *  Used for testing purposes in qemu user mode only!
+ *  The OS does not have a 'stdout' just yet, but running
+ *  code in qemu user mode means we can use linux syscalls.
+ *  This is used for debugging for now.
+ *
+ *  @param  string you want to print to stdout
+ *  @param  length of the string
+ *  @return void
+ */
+void print(char* message, unsigned short len);
 
 #endif /* INCLUDE_IO_H */

--- a/kernel/include/libc.h
+++ b/kernel/include/libc.h
@@ -1,5 +1,9 @@
 #include "types.h"
+#include "va_list.h"
 
-extern void * memcpy(void * dest, const void * src, size_t n);
+void * memcpy(void * dest, const void * src, size_t n);
 
-unsigned int strlen(char *s);
+unsigned int strlen(const char *s);
+size_t vasprintf(char * buf, size_t size, char * fmt, ...);
+
+int strcmp(const char * l, const char * r);

--- a/kernel/include/system.h
+++ b/kernel/include/system.h
@@ -3,7 +3,5 @@
 
 #include "types.h"
 extern uint32_t boot_time;
-extern uint32_t timer_ticks;
-extern uint32_t timer_subticks;
 
 #endif

--- a/kernel/include/system.h
+++ b/kernel/include/system.h
@@ -3,5 +3,7 @@
 
 #include "types.h"
 extern uint32_t boot_time;
+extern uint32_t timer_ticks;
+extern uint32_t timer_subticks;
 
 #endif

--- a/kernel/include/types.h
+++ b/kernel/include/types.h
@@ -1,9 +1,18 @@
 #ifndef INCLUDE_TYPES_H
 #define INCLUDE_TYPES_H
 
+#define NULL ((void *)0)
+#define UINT32_MAX 0xffffffff
+
 typedef unsigned char           uint8_t;
 typedef unsigned short int      uint16_t;
 typedef unsigned int            uint32_t;
 typedef unsigned long size_t;
+
+// sys/time.h
+struct timeval {
+   uint32_t tv_sec;     /* seconds */
+   uint32_t tv_usec;    /* microseconds */
+};
 
 #endif

--- a/kernel/include/va_list.h
+++ b/kernel/include/va_list.h
@@ -1,0 +1,8 @@
+#pragma once
+
+typedef __builtin_va_list va_list;
+#define va_start(ap,last) __builtin_va_start(ap, last)
+#define va_end(ap) __builtin_va_end(ap)
+#define va_arg(ap,type) __builtin_va_arg(ap,type)
+#define va_copy(dest, src) __builtin_va_copy(dest,src)
+

--- a/kernel/libc.c
+++ b/kernel/libc.c
@@ -1,6 +1,7 @@
-#include "types.h"
+#include "libc.h"
+#include "serial.h"
 
-void * memcpy(void * dest, void * src, size_t n)
+void * memcpy(void * dest, const void * src, size_t n)
 {
     asm volatile("cld; rep movsb"
                 : "=c"((int){0})
@@ -9,7 +10,7 @@ void * memcpy(void * dest, void * src, size_t n)
     return dest;
 }
 
-unsigned int strlen(char *s)
+unsigned int strlen(const char *s)
 {
     unsigned int len = 0;
     while (s[len] != '\0') {
@@ -17,4 +18,103 @@ unsigned int strlen(char *s)
     }
 
     return len;
+}
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
+size_t vasprintf(char * buf, size_t size, char * fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    char *c = buf;
+    char *s;
+    // Walk string until we reach a null byte
+    for (char *f = fmt; *f; f++) {
+        if (size < 1) {
+            // We have reached end of our buffer
+            return 1;
+        }
+        if (*f != '%') {
+            *c++ = *f;
+            size--;
+            continue;
+        }
+
+        // TODO: Add argument width
+        ++f;
+        uint32_t test = 0;
+        switch (*f) {
+            case 's':
+                s = va_arg(args, char *);
+                while (*s) {
+                    if (size < 1) return 1;
+                    *c++ = *s++;
+                    size--;
+                }
+                break;
+            case '%':
+                *c++ = '%';
+                break;
+            case 'd':
+                test = va_arg(args, uint32_t); 
+                uint32_t i = 9;
+                // How many digits the number is
+                uint32_t num_width = 1;
+                while (test > i && i < UINT32_MAX) {
+                    i *= 10;
+                    i += 9;
+                    num_width++;
+                }
+                // TODO: Nasty hack but I can't figure out
+                // why numbers near UINT32_MAX end up with
+                // a width of 12 at the moment.
+                if (num_width == 12) num_width = 10;
+
+                c += num_width - 1;
+                char *start_pos = c + 1;
+                while (num_width > 0) {
+                    unsigned int value = test / 10;
+                    unsigned int digit = test % 10;
+                    *c-- = digit + '0';
+                    test = value;
+                    num_width--;
+                }
+                c = start_pos;
+                break;
+        }
+        size--;
+    }
+    va_end(args);
+    return 0;
+}
+#pragma GCC diagnostic pop
+#pragma GCC diagnostic pop
+#pragma GCC diagnostic pop
+
+/* void dec_to_str(char * buf, unsigned int value, unsigned int width) */
+/* { */
+/*     unsigned int num_width = 1; */
+/*     unsigned int n = 9; */
+/*     while (value > 9 && value < UINT32_MAX) { */
+/*         n *= 10; */
+/*         n += 9; */
+/*         num_width++; */
+/*     } */
+
+/*     while (num_width > 0) { */
+/*         unsigned int next_divisor = value / 10; */
+/*         unsigned int remainder = value % 10; */
+/*         buf[num_width] = remainder + '0'; */
+/*         num_width--; */
+/*         value = next_divisor; */
+/*     } */
+/* } */
+
+int strcmp(const char * l, const char * r) {
+	for (; *l == *r && *l; l++, r++);
+	return *(unsigned char *)l - *(unsigned char *)r;
 }

--- a/kmain.c
+++ b/kmain.c
@@ -26,10 +26,6 @@ void fb_write_cell()
 
 int main()
 {
-    /* for (int i = 0; i < 401; i++) { */
-    /*     fb_write(text, len); */
-    /* } */
-
     serial_init();
     serial_write("Booting the OS\n");
     gdt_init();

--- a/kmain.c
+++ b/kmain.c
@@ -36,20 +36,6 @@ int main()
     idt_init();
     asm volatile("sti");
     timer_init(1000); // Initialise timer to 50Hz
-    serial_write("Hello\n");
-    /* asm volatile ("int $0x1"); */
-    /* asm volatile ("int $0x2"); */
-    struct timeval tv;
-    gettimeofday(&tv, NULL);
-    char buf[100];
-    /* vasprintf(buf, sizeof buf / sizeof(buf[0]), "This number is\n"); */
-    /* serial_write(buf); */
-    /* /1* vasprintf(buf, "The next number is %d\n", 150); *1/ */
-    /* /1* serial_write(buf); *1/ */
-    /* vasprintf(buf, sizeof buf / sizeof(buf[0]), "The next number %s\n", "testasdfasdfds"); */
-    /* serial_write(buf); */
-    vasprintf(buf, sizeof buf / sizeof(buf[0]), "Current %d  time is: %d  \n", 2500, 150);
-    serial_write(buf);
     return 0;
 }
 

--- a/kmain.c
+++ b/kmain.c
@@ -5,6 +5,7 @@
 #include "idt.h"
 #include "libc.h"
 #include "timer.h"
+#include "cmos.h"
 
 /* The C function */
 int sum_of_three(int arg1, int arg2, int arg3)
@@ -23,19 +24,32 @@ void fb_write_cell()
     fb[5] = 0xf0;
 }
 
-void hello()
+int main()
 {
     /* for (int i = 0; i < 401; i++) { */
     /*     fb_write(text, len); */
     /* } */
 
     serial_init();
+    serial_write("Booting the OS\n");
     gdt_init();
     idt_init();
     asm volatile("sti");
-    timer_init(50); // Initialise timer to 50Hz
-    serial_write("Hello");
+    timer_init(1000); // Initialise timer to 50Hz
+    serial_write("Hello\n");
     /* asm volatile ("int $0x1"); */
     /* asm volatile ("int $0x2"); */
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    char buf[100];
+    /* vasprintf(buf, sizeof buf / sizeof(buf[0]), "This number is\n"); */
+    /* serial_write(buf); */
+    /* /1* vasprintf(buf, "The next number is %d\n", 150); *1/ */
+    /* /1* serial_write(buf); *1/ */
+    /* vasprintf(buf, sizeof buf / sizeof(buf[0]), "The next number %s\n", "testasdfasdfds"); */
+    /* serial_write(buf); */
+    vasprintf(buf, sizeof buf / sizeof(buf[0]), "Current %d  time is: %d  \n", 2500, 150);
+    serial_write(buf);
+    return 0;
 }
 

--- a/loader.s
+++ b/loader.s
@@ -1,5 +1,5 @@
 global start                    ; the entry symbol for ELF
-extern hello
+extern main
 
 KERNEL_STACK_SIZE equ 4096      ; size of stack in bytes
 MAGIC_NUMBER equ 0x1BADB002     ; define the magic number constant
@@ -18,7 +18,7 @@ align 4                         ; the code must be 4 byte aligned
 start:                         ; the loader label (defined as entry point in linker script)
     mov esp, kernel_stack + KERNEL_STACK_SIZE   ; point esp to the start of the
     ; Working with the cursor
-    call hello
+    call main
 .loop:
     jmp .loop                   ; loop forever
 

--- a/script/gdb-init
+++ b/script/gdb-init
@@ -1,2 +1,4 @@
-symbol-file kernel.elf
-target remote 192.168.1.166:1234
+symbol-file tests/test.elf
+# Major fucking footgun.  Make sure to update with current host IP
+# and that it does not conflict with Docker's bip.
+target remote localhost:1234

--- a/tests/test.s
+++ b/tests/test.s
@@ -1,0 +1,17 @@
+section .text
+; Export the entry point to the ELF linker or loader.  The conventional
+; entry point is "_start". Use "ld -e foo" to override the default.
+global _start
+extern testsuite
+
+section .text
+
+; linker puts the entry point here:
+_start:
+
+; Exit via the kernel:
+
+    call testsuite
+    mov al, 1 ; Function 1: exit()
+    mov ebx, 0 ; Return code
+    int 0x80 ; The only interrupt Linux uses!

--- a/tests/testsuite.c
+++ b/tests/testsuite.c
@@ -1,0 +1,107 @@
+#include "libc.h"
+#include "io.h"
+#include "cmos.h"
+
+typedef int(*testfunc) (void);
+static unsigned int test_count = 0;
+static testfunc tests[100];
+
+int passing_test()
+{
+    return 0;
+}
+
+int test_secs_of_month_jan_2018()
+{
+    return secs_of_month(1, 18) != 2678400;
+}
+
+int test_secs_of_month_feb_2018()
+{
+    return secs_of_month(2, 18) != 5097600;
+}
+
+int test_secs_of_month_mar_2018()
+{
+    return secs_of_month(3, 18) != (5097600 + 2678400);
+}
+
+int test_get_timestamp_from_cmos_reigsters()
+{
+    uint32_t expected = 1527153647;
+    uint32_t actual = get_timestamp_from_cmos_registers(
+        47,
+        20,
+        5,
+        24,
+        5,
+        18
+    );
+    return (actual - expected) != 0;
+}
+
+int test_secs_of_year_2018()
+{
+    return secs_of_years(17) != 1514764800;
+}
+
+int test_vasprintf_with_numbers()
+{
+    char expected[] = "1527125201 1527125201";
+    uint32_t len = strlen(expected);
+    char buf[len];
+    vasprintf(buf, sizeof(buf)/sizeof(buf[0]), "%d %d", 1527125201, 1527125201);
+    return strcmp(buf, expected);
+}
+
+int test_vasprintf_escapes_percent_signs()
+{
+    char expected[] = "%";
+    uint32_t len = strlen(expected);
+    char buf[len];
+    vasprintf(buf, sizeof(buf)/sizeof(buf[0]), "%%");
+    print(buf, strlen(buf));
+    return strcmp(buf, expected);
+}
+
+void test(testfunc test)
+{
+    tests[test_count++] = test;
+}
+
+void run()
+{
+    print("1..", 3);
+    char buf[100];
+    vasprintf(buf, sizeof buf / sizeof buf[0], "%d \n", test_count);
+    print(buf, strlen(buf));
+    for (unsigned int i = 0; i < test_count; i++) {
+        testfunc test = tests[i];
+        int result = test();
+        if (result == 0) {
+            char msg[] = "ok";
+            print(msg, strlen(msg));
+        } else {
+            char msg[] = "not ok";
+            print(msg, strlen(msg));
+        }
+
+        print("\n", 1);
+    }
+}
+
+extern int testsuite()
+{
+    test(test_get_timestamp_from_cmos_reigsters);
+    test(test_vasprintf_with_numbers);
+    test(test_vasprintf_escapes_percent_signs);
+    test(passing_test);
+    test(test_secs_of_month_jan_2018);
+    test(test_secs_of_month_feb_2018);
+    test(test_secs_of_month_mar_2018);
+    test(test_secs_of_year_2018);
+
+    run();
+    return 0;
+}
+

--- a/tests/testsuite.c
+++ b/tests/testsuite.c
@@ -48,8 +48,7 @@ int test_secs_of_year_2018()
 int test_vasprintf_with_numbers()
 {
     char expected[] = "1527125201 1527125201";
-    uint32_t len = strlen(expected);
-    char buf[len];
+    char buf[1000];
     vasprintf(buf, sizeof(buf)/sizeof(buf[0]), "%d %d", 1527125201, 1527125201);
     return strcmp(buf, expected);
 }
@@ -57,10 +56,8 @@ int test_vasprintf_with_numbers()
 int test_vasprintf_escapes_percent_signs()
 {
     char expected[] = "%";
-    uint32_t len = strlen(expected);
-    char buf[len];
+    char buf[1000];
     vasprintf(buf, sizeof(buf)/sizeof(buf[0]), "%%");
-    print(buf, strlen(buf));
     return strcmp(buf, expected);
 }
 


### PR DESCRIPTION
## Todo
- [x] Fix test that seems to be overwriting an existing buffer  -- allocating larger buffers work.  I think I need to audit vasprintf more strictly to understand what is going on.
- [x] Clean up all the logging
- [x] Update Vagrant file to work from scratch
- [x] Check time matches current unixtime a final time!